### PR TITLE
Fix tag of mysql image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ hs_err_pid*
 target
 .idea
 
+*.iml

--- a/src/db/Dockerfile
+++ b/src/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql
+FROM mysql:5.7.22
 
 ENV MYSQL_RANDOM_ROOT_PASSWORD="yes"
 # this is meant for debugging only - DO NOT use in production!


### PR DESCRIPTION
The mysql images in DockerHub have updated and newer versions change the default auth mechanism. This causes the web container to fail authentication to the db container. Fixing the mysql tag to 5.7.22 mitigates this issue.